### PR TITLE
Update Cpf.vue

### DIFF
--- a/src/components/Cpf.vue
+++ b/src/components/Cpf.vue
@@ -42,7 +42,7 @@ export default {
       type: Object,
       default: function() {
         return {
-          outputMask: "##########",
+          outputMask: "###########",
           empty: "",
           applyAfter: false,
         };


### PR DESCRIPTION
Correção do outputMask. 
Adiciona o 11º digito de retorno que não era computado.

-------------------------------------------------------------------------
Please verify this pull request. This commit rectify the outputmask of cpf values.