### PR TITLE
Fix error when last character is typed

### DIFF
--- a/src/components/Cpf.vue
+++ b/src/components/Cpf.vue
@@ -185,13 +185,13 @@ export default {
       // Validar 1o digito
       let add = 0;
       for (var i = 0; i < 9; i++) add += parseInt(cpf.charAt(i)) * (10 - i);
-      rev = 11 - (add % 11);
+      let rev = 11 - (add % 11);
       if (rev == 10 || rev == 11) rev = 0;
       if (rev != parseInt(cpf.charAt(9))) return false;
       // Validar 2o digito
       add = 0;
       for (var j = 0; j < 10; j++) add += parseInt(cpf.charAt(j)) * (11 - j);
-      let rev = 11 - (add % 11);
+      rev = 11 - (add % 11);
       if (rev == 10 || rev == 11) rev = 0;
       if (rev != parseInt(cpf.charAt(10))) return false;
       return true;


### PR DESCRIPTION
Using the CPF component with this settings but I think the bug doesn't depend of it.
After press the last number of the CPF, an error raises: 

`vendor.js?id=cee1e9000fa7c75af088:5824 [Vue warn]: Error in v-on handler: "ReferenceError: Cannot access 'rev' before initialization"`

```vue
<v-text-field-cpf
    v-model="cpf"
    v-bind:properties="{
        outlined: true,
        clearable: true,
        placeholder: '',
    }"
    v-bind:options="{
        outputMask: '###########',
        empty: null,
        applyAfter: true,
    }"
/>
```